### PR TITLE
fix(ethcli): improve Kong price source reliability

### DIFF
--- a/crates/ethcli/src/aggregator/price.rs
+++ b/crates/ethcli/src/aggregator/price.rs
@@ -1806,12 +1806,12 @@ async fn fetch_kong_price(
     // Fetch price from Kong (uses limit: 1 for fast single-price lookup)
     match client.prices().current(chain_id, token).await {
         Ok(Some(price_data)) => {
-            if price_data.price_usd <= 0.0 {
+            if !price_data.price_usd.is_finite() || price_data.price_usd <= 0.0 {
                 return SourceResult::error(
                     "kong",
                     format!(
-                        "Zero price returned for {} (source: {})",
-                        token, price_data.price_source
+                        "Invalid or non-positive price ({}) returned for {} (source: {})",
+                        price_data.price_usd, token, price_data.price_source
                     ),
                     measure.elapsed_ms(),
                 );


### PR DESCRIPTION
## Summary
- Reject zero prices from Kong — reports ERR instead of `$0 OK`, preventing polluted aggregated medians
- Add KongVault to default `fetch_prices_all` sources (was missing after merge)
- Replace Kong with Enso in kong_vault underlying sources — Kong downloads massive historical data for vault underlyings causing 30s timeouts; Enso responds in ~1s

## Test plan
- [x] `ethcli price 0xCa960E6D... --source kong` → ERR (zero price) in ~400ms
- [x] `ethcli price 0xCa960E6D... --source kong-vault` → $0.130017 in ~1.8s (was 30s)
- [x] `ethcli price 0xCa960E6D...` → aggregated shows kong_vault + enso both ~$0.1300
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)