### PR TITLE
[codex] guard Moralis legacy deprecations

### DIFF
--- a/crates/ethcli-mcp/README.md
+++ b/crates/ethcli-mcp/README.md
@@ -166,6 +166,11 @@ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":
 | `SOLODIT_API_KEY` | `solodit_*` tools |
 | `THEGRAPH_API_KEY` | `uniswap_top_pools`, etc. |
 
+Moralis is removing Fantom support on 2026-05-29 and selected legacy Data API
+endpoints on 2026-06-04. The MCP `moralis_*` tools inherit the same ethcli
+guards for Fantom and deprecated Discovery, Volume, Market Data, pair sniper,
+and selected ERC20 helper endpoints.
+
 ## Unverified Contract Analysis
 
 The `contract_analyze` MCP tool exposes ethcli's native unverified-contract workflow. Set `follow_proxy`, `lookup`, `dispatcher`, and `checks` to inspect proxy implementations, resolve selectors, map selector handlers, and flag side-effecting handler bodies that appear to lack caller gates or calldata hash validation. `contract_selectors` also supports `follow_proxy` when you want implementation selectors rather than proxy wrapper selectors.

--- a/crates/ethcli/LLMREF.md
+++ b/crates/ethcli/LLMREF.md
@@ -177,6 +177,10 @@ ethcli llama yields --chain ethereum
 ```
 
 ### Moralis (requires MORALIS_API_KEY)
+Fantom is blocked for Moralis calls after Moralis' 2026-05-29 removal notice.
+Legacy Discovery, Volume, Market Data, selected ERC20 helper, and pair sniper
+commands are blocked ahead of the 2026-06-04 endpoint removal.
+
 ```bash
 ethcli moralis balance <addr>
 ethcli moralis tokens <addr>

--- a/crates/ethcli/README.md
+++ b/crates/ethcli/README.md
@@ -669,6 +669,11 @@ ethcli llama stablecoin-history tether
 
 Requires `MORALIS_API_KEY` environment variable.
 
+Moralis is removing Fantom support on 2026-05-29 and selected legacy Data API
+endpoints on 2026-06-04. `ethcli moralis` blocks Fantom chain aliases and the
+legacy Discovery, Volume, Market Data, pair sniper, and selected ERC20 helper
+commands affected by that changelog.
+
 ```bash
 # Wallet data
 ethcli moralis balance 0x...

--- a/crates/ethcli/src/cli/moralis.rs
+++ b/crates/ethcli/src/cli/moralis.rs
@@ -6,6 +6,210 @@ use crate::cli::OutputFormat;
 use crate::config::ConfigFile;
 use clap::{Args, Subcommand};
 
+const MORALIS_FANTOM_REMOVAL_DATE: &str = "2026-05-29";
+const MORALIS_LEGACY_REMOVAL_DATE: &str = "2026-06-04";
+
+fn ensure_moralis_chain_supported(chain: &str) -> anyhow::Result<()> {
+    match chain.trim().to_ascii_lowercase().as_str() {
+        "fantom" | "ftm" | "0xfa" | "250" => anyhow::bail!(
+            "Moralis is removing Fantom support on {MORALIS_FANTOM_REMOVAL_DATE}; \
+             ethcli no longer routes Moralis requests to Fantom. Use another provider \
+             or migrate Fantom-specific workflows before relying on this command."
+        ),
+        _ => Ok(()),
+    }
+}
+
+fn deprecated_moralis_endpoint(
+    command: &str,
+    endpoints: &[&str],
+    replacement: Option<&str>,
+) -> anyhow::Result<()> {
+    let endpoint_list = endpoints.join(", ");
+    let mut message = format!(
+        "`ethcli moralis {command}` calls Moralis endpoint(s) scheduled for removal on \
+         {MORALIS_LEGACY_REMOVAL_DATE}: {endpoint_list}."
+    );
+
+    if let Some(replacement) = replacement {
+        message.push_str(" Suggested migration: ");
+        message.push_str(replacement);
+        message.push('.');
+    }
+
+    anyhow::bail!("{message}")
+}
+
+fn moralis_command_args(command: &MoralisCommands) -> &MoralisArgs {
+    match command {
+        MoralisCommands::Wallet { args, .. }
+        | MoralisCommands::Token { args, .. }
+        | MoralisCommands::Nft { args, .. }
+        | MoralisCommands::Resolve { args, .. }
+        | MoralisCommands::Market { args, .. }
+        | MoralisCommands::Transaction { args, .. }
+        | MoralisCommands::Block { args, .. }
+        | MoralisCommands::Defi { args, .. }
+        | MoralisCommands::Discovery { args, .. }
+        | MoralisCommands::Analytics { args, .. }
+        | MoralisCommands::Entities { args, .. }
+        | MoralisCommands::Volume { args, .. } => args,
+    }
+}
+
+fn reject_deprecated_moralis_command(command: &MoralisCommands) -> anyhow::Result<()> {
+    match command {
+        MoralisCommands::Token { action, .. } => match action {
+            TokenCommands::Stats { .. } => deprecated_moralis_endpoint(
+                "token stats",
+                &["GET /erc20/{address}/stats"],
+                Some("use Moralis Token API analytics where available"),
+            ),
+            TokenCommands::ExchangeNewTokens { .. } => deprecated_moralis_endpoint(
+                "token exchange-new-tokens",
+                &["GET /erc20/exchange/{exchangeName}/new"],
+                None,
+            ),
+            TokenCommands::ExchangeBondingTokens { .. } => deprecated_moralis_endpoint(
+                "token exchange-bonding-tokens",
+                &["GET /erc20/exchange/{exchangeName}/bonding"],
+                None,
+            ),
+            TokenCommands::ExchangeGraduatedTokens { .. } => deprecated_moralis_endpoint(
+                "token exchange-graduated-tokens",
+                &["GET /erc20/exchange/{exchangeName}/graduated"],
+                None,
+            ),
+            TokenCommands::BySymbols { .. } => deprecated_moralis_endpoint(
+                "token by-symbols",
+                &["GET /erc20/metadata/symbols"],
+                Some("use `ethcli moralis token search <symbol>` for one symbol at a time"),
+            ),
+            TokenCommands::PairsStats { .. } => deprecated_moralis_endpoint(
+                "token pairs-stats",
+                &["GET /erc20/{token_address}/pairs/stats"],
+                Some("migrate to `GET /tokens/{tokenAddress}/analytics`"),
+            ),
+            TokenCommands::PairSnipers { .. } => deprecated_moralis_endpoint(
+                "token pair-snipers",
+                &["GET /pairs/{address}/snipers"],
+                None,
+            ),
+            TokenCommands::BondingStatus { .. } => deprecated_moralis_endpoint(
+                "token bonding-status",
+                &["GET /erc20/{tokenAddress}/bondingStatus"],
+                None,
+            ),
+            _ => Ok(()),
+        },
+        MoralisCommands::Market { action, .. } => match action {
+            MarketCommands::TopTokens => deprecated_moralis_endpoint(
+                "market top-tokens",
+                &["GET /market-data/erc20s/top-tokens"],
+                None,
+            ),
+            MarketCommands::TopMovers => deprecated_moralis_endpoint(
+                "market top-movers",
+                &["GET /market-data/erc20s/top-movers"],
+                None,
+            ),
+            MarketCommands::TopNfts => deprecated_moralis_endpoint(
+                "market top-nfts",
+                &["GET /market-data/nfts/top-collections"],
+                None,
+            ),
+            MarketCommands::HottestNfts => deprecated_moralis_endpoint(
+                "market hottest-nfts",
+                &["GET /market-data/nfts/hottest-collections"],
+                None,
+            ),
+            MarketCommands::GlobalMarketCap => deprecated_moralis_endpoint(
+                "market global-market-cap",
+                &["GET /market-data/global/market-cap"],
+                None,
+            ),
+            MarketCommands::GlobalVolume => deprecated_moralis_endpoint(
+                "market global-volume",
+                &["GET /market-data/global/volume"],
+                None,
+            ),
+        },
+        MoralisCommands::Discovery { action, .. } => match action {
+            DiscoveryCommands::RisingLiquidity => deprecated_moralis_endpoint(
+                "discovery rising-liquidity",
+                &["GET /discovery/tokens/rising-liquidity"],
+                None,
+            ),
+            DiscoveryCommands::BuyingPressure => deprecated_moralis_endpoint(
+                "discovery buying-pressure",
+                &["GET /discovery/tokens/buying-pressure"],
+                None,
+            ),
+            DiscoveryCommands::SolidPerformers => deprecated_moralis_endpoint(
+                "discovery solid-performers",
+                &["GET /discovery/tokens/solid-performers"],
+                None,
+            ),
+            DiscoveryCommands::ExperiencedBuyers => deprecated_moralis_endpoint(
+                "discovery experienced-buyers",
+                &["GET /discovery/tokens/experienced-buyers"],
+                None,
+            ),
+            DiscoveryCommands::RiskyBets => deprecated_moralis_endpoint(
+                "discovery risky-bets",
+                &["GET /discovery/tokens/risky-bets"],
+                None,
+            ),
+            DiscoveryCommands::BlueChip => deprecated_moralis_endpoint(
+                "discovery blue-chip",
+                &["GET /discovery/tokens/blue-chip"],
+                None,
+            ),
+            DiscoveryCommands::TopGainers => deprecated_moralis_endpoint(
+                "discovery top-gainers",
+                &["GET /discovery/tokens/top-gainers"],
+                None,
+            ),
+            DiscoveryCommands::TopLosers => deprecated_moralis_endpoint(
+                "discovery top-losers",
+                &["GET /discovery/tokens/top-losers"],
+                None,
+            ),
+            DiscoveryCommands::Trending => deprecated_moralis_endpoint(
+                "discovery trending",
+                &["GET /discovery/tokens/trending"],
+                Some("use `ethcli moralis token trending`"),
+            ),
+            DiscoveryCommands::Filter { .. } => {
+                deprecated_moralis_endpoint("discovery filter", &["POST /discovery/tokens"], None)
+            }
+            DiscoveryCommands::Token { .. } => {
+                deprecated_moralis_endpoint("discovery token", &["GET /discovery/token"], None)
+            }
+            DiscoveryCommands::TokenAnalytics { .. } | DiscoveryCommands::TokenScore { .. } => {
+                Ok(())
+            }
+        },
+        MoralisCommands::Volume { action, .. } => match action {
+            VolumeCommands::Chains => {
+                deprecated_moralis_endpoint("volume chains", &["GET /volume/chains"], None)
+            }
+            VolumeCommands::Categories => {
+                deprecated_moralis_endpoint("volume categories", &["GET /volume/categories"], None)
+            }
+            VolumeCommands::Timeseries { .. } => {
+                deprecated_moralis_endpoint("volume timeseries", &["GET /volume/timeseries"], None)
+            }
+            VolumeCommands::CategoryTimeseries { .. } => deprecated_moralis_endpoint(
+                "volume category-timeseries",
+                &["GET /volume/timeseries/{category_id}"],
+                None,
+            ),
+        },
+        _ => Ok(()),
+    }
+}
+
 #[derive(Args)]
 pub struct MoralisArgs {
     /// Chain (e.g., eth, polygon, bsc, arbitrum)
@@ -883,6 +1087,10 @@ pub enum VolumeCommands {
 pub async fn handle(command: &MoralisCommands, quiet: bool) -> anyhow::Result<()> {
     use secrecy::ExposeSecret;
 
+    let args = moralis_command_args(command);
+    ensure_moralis_chain_supported(&args.chain)?;
+    reject_deprecated_moralis_command(command)?;
+
     // Try config first, then fall back to env var
     let client = if let Ok(Some(config)) = ConfigFile::load_default() {
         if let Some(ref moralis_config) = config.moralis {
@@ -1037,6 +1245,7 @@ async fn handle_wallet(
     Ok(())
 }
 
+#[allow(deprecated)]
 async fn handle_token(
     client: &mrls::Client,
     action: &TokenCommands,
@@ -1667,6 +1876,7 @@ async fn handle_resolve(
     Ok(())
 }
 
+#[allow(deprecated)]
 async fn handle_market(
     client: &mrls::Client,
     action: &MarketCommands,
@@ -1926,6 +2136,7 @@ async fn handle_defi(
     Ok(())
 }
 
+#[allow(deprecated)]
 async fn handle_discovery(
     client: &mrls::Client,
     action: &DiscoveryCommands,
@@ -2167,6 +2378,7 @@ async fn handle_entities(
     Ok(())
 }
 
+#[allow(deprecated)]
 async fn handle_volume(
     client: &mrls::Client,
     action: &VolumeCommands,
@@ -2251,4 +2463,76 @@ fn print_output<T: serde::Serialize>(data: &T, format: OutputFormat) -> anyhow::
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        deprecated_moralis_endpoint, reject_deprecated_moralis_command, DiscoveryCommands,
+        MoralisArgs, MoralisCommands, OutputFormat,
+    };
+    use super::{ensure_moralis_chain_supported, TokenCommands};
+
+    #[test]
+    fn moralis_fantom_aliases_are_blocked() {
+        for chain in ["fantom", "Fantom", "ftm", "250", "0xfa"] {
+            assert!(ensure_moralis_chain_supported(chain).is_err());
+        }
+    }
+
+    #[test]
+    fn supported_moralis_chains_still_pass() {
+        for chain in ["eth", "polygon", "bsc", "arbitrum", "base", "optimism"] {
+            assert!(ensure_moralis_chain_supported(chain).is_ok());
+        }
+    }
+
+    #[test]
+    fn deprecated_endpoint_message_names_command_and_endpoint() {
+        let error =
+            deprecated_moralis_endpoint("market top-tokens", &["GET /market-data/test"], None)
+                .unwrap_err()
+                .to_string();
+
+        assert!(error.contains("market top-tokens"));
+        assert!(error.contains("GET /market-data/test"));
+        assert!(error.contains("2026-06-04"));
+    }
+
+    #[test]
+    fn deprecated_moralis_commands_are_rejected_before_client_setup() {
+        let args = MoralisArgs {
+            chain: "eth".to_string(),
+            format: OutputFormat::Json,
+        };
+        let command = MoralisCommands::Token {
+            action: TokenCommands::PairSnipers {
+                address: "0xpair".to_string(),
+            },
+            args,
+        };
+
+        let error = reject_deprecated_moralis_command(&command)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("pair-snipers"));
+        assert!(error.contains("/pairs/{address}/snipers"));
+    }
+
+    #[test]
+    fn non_deprecated_moralis_commands_are_not_rejected() {
+        let args = MoralisArgs {
+            chain: "eth".to_string(),
+            format: OutputFormat::Json,
+        };
+        let command = MoralisCommands::Discovery {
+            action: DiscoveryCommands::TokenScore {
+                address: "0xtoken".to_string(),
+            },
+            args,
+        };
+
+        assert!(reject_deprecated_moralis_command(&command).is_ok());
+    }
 }

--- a/crates/mrls/README.md
+++ b/crates/mrls/README.md
@@ -16,15 +16,23 @@
 ## Features
 
 - **Wallet API** - Native balances, token balances, transactions, approvals, net worth, profitability
-- **Token API** - Metadata, prices, transfers, swaps, pairs, holders, stats, trending
+- **Token API** - Metadata, prices, transfers, swaps, pairs, holders, trending
 - **NFT API** - NFT metadata, transfers, owners, trades, floor prices, collections
 - **DeFi API** - Pair prices, reserves, positions, protocol summaries
 - **Block API** - Block data, timestamps, date-to-block lookups
 - **Transaction API** - Transaction details, decoded calls, internal transactions
 - **Resolve API** - ENS, Unstoppable Domains, domain resolution
-- **Market Data API** - Top tokens, movers, NFT collections, global stats
-- **Discovery API** - Token discovery, trending, analytics, scores
+- **Market Data API** - Legacy endpoints scheduled for Moralis removal on 2026-06-04
+- **Discovery API** - Legacy discovery endpoints scheduled for Moralis removal on 2026-06-04
 - **Entities API** - Wallet/protocol/exchange labels and categories
+
+## Moralis Deprecations
+
+Moralis is removing Fantom support across all APIs on 2026-05-29. It is also
+removing Cortex and selected legacy Data API endpoints on 2026-06-04. The
+affected `mrls` methods are annotated with `#[deprecated]`, including legacy
+Discovery, Volume, Market Data, selected ERC20 stats/discovery helpers, and pair
+sniper endpoints.
 
 ## Installation
 

--- a/crates/mrls/src/discovery/api.rs
+++ b/crates/mrls/src/discovery/api.rs
@@ -55,6 +55,9 @@ impl<'a> DiscoveryApi<'a> {
     }
 
     /// Get tokens with rising liquidity
+    #[deprecated(
+        note = "Moralis is sunsetting GET /discovery/tokens/rising-liquidity on 2026-06-04"
+    )]
     pub async fn get_rising_liquidity(
         &self,
         query: Option<&DiscoveryQuery>,
@@ -68,6 +71,9 @@ impl<'a> DiscoveryApi<'a> {
     }
 
     /// Get tokens with buying pressure
+    #[deprecated(
+        note = "Moralis is sunsetting GET /discovery/tokens/buying-pressure on 2026-06-04"
+    )]
     pub async fn get_buying_pressure(
         &self,
         query: Option<&DiscoveryQuery>,
@@ -81,6 +87,9 @@ impl<'a> DiscoveryApi<'a> {
     }
 
     /// Get solid performers
+    #[deprecated(
+        note = "Moralis is sunsetting GET /discovery/tokens/solid-performers on 2026-06-04"
+    )]
     pub async fn get_solid_performers(
         &self,
         query: Option<&DiscoveryQuery>,
@@ -94,6 +103,9 @@ impl<'a> DiscoveryApi<'a> {
     }
 
     /// Get tokens with experienced buyers
+    #[deprecated(
+        note = "Moralis is sunsetting GET /discovery/tokens/experienced-buyers on 2026-06-04"
+    )]
     pub async fn get_experienced_buyers(
         &self,
         query: Option<&DiscoveryQuery>,
@@ -107,6 +119,7 @@ impl<'a> DiscoveryApi<'a> {
     }
 
     /// Get risky bet tokens
+    #[deprecated(note = "Moralis is sunsetting GET /discovery/tokens/risky-bets on 2026-06-04")]
     pub async fn get_risky_bets(
         &self,
         query: Option<&DiscoveryQuery>,
@@ -120,6 +133,7 @@ impl<'a> DiscoveryApi<'a> {
     }
 
     /// Get blue chip tokens
+    #[deprecated(note = "Moralis is sunsetting GET /discovery/tokens/blue-chip on 2026-06-04")]
     pub async fn get_blue_chip(&self, query: Option<&DiscoveryQuery>) -> Result<DiscoveryResponse> {
         let path = "/discovery/tokens/blue-chip";
         if let Some(q) = query {
@@ -130,6 +144,7 @@ impl<'a> DiscoveryApi<'a> {
     }
 
     /// Get top gainers
+    #[deprecated(note = "Moralis is sunsetting GET /discovery/tokens/top-gainers on 2026-06-04")]
     pub async fn get_top_gainers(
         &self,
         query: Option<&DiscoveryQuery>,
@@ -143,6 +158,7 @@ impl<'a> DiscoveryApi<'a> {
     }
 
     /// Get top losers
+    #[deprecated(note = "Moralis is sunsetting GET /discovery/tokens/top-losers on 2026-06-04")]
     pub async fn get_top_losers(
         &self,
         query: Option<&DiscoveryQuery>,
@@ -156,6 +172,9 @@ impl<'a> DiscoveryApi<'a> {
     }
 
     /// Get trending tokens
+    #[deprecated(
+        note = "Moralis is sunsetting GET /discovery/tokens/trending on 2026-06-04; use /tokens/trending instead"
+    )]
     pub async fn get_trending(&self, query: Option<&DiscoveryQuery>) -> Result<DiscoveryResponse> {
         let path = "/discovery/tokens/trending";
         if let Some(q) = query {
@@ -196,11 +215,13 @@ impl<'a> DiscoveryApi<'a> {
     }
 
     /// Filter tokens with custom criteria
+    #[deprecated(note = "Moralis is sunsetting POST /discovery/tokens on 2026-06-04")]
     pub async fn filter_tokens(&self, filter: &DiscoveryFilter) -> Result<DiscoveryResponse> {
         self.client.post("/discovery/tokens", filter).await
     }
 
     /// Get single token details from discovery
+    #[deprecated(note = "Moralis is sunsetting GET /discovery/token on 2026-06-04")]
     pub async fn get_token(&self, address: &str, chain: Option<&str>) -> Result<DiscoveredToken> {
         #[derive(Serialize)]
         struct TokenQuery {

--- a/crates/mrls/src/market/api.rs
+++ b/crates/mrls/src/market/api.rs
@@ -45,6 +45,7 @@ impl<'a> MarketApi<'a> {
     }
 
     /// Get top ERC20 tokens by market cap
+    #[deprecated(note = "Moralis is sunsetting GET /market-data/erc20s/top-tokens on 2026-06-04")]
     pub async fn get_top_tokens(&self, query: Option<&MarketQuery>) -> Result<Vec<TopToken>> {
         let path = "/market-data/erc20s/top-tokens";
         if let Some(q) = query {
@@ -55,6 +56,7 @@ impl<'a> MarketApi<'a> {
     }
 
     /// Get top gainers and losers
+    #[deprecated(note = "Moralis is sunsetting GET /market-data/erc20s/top-movers on 2026-06-04")]
     pub async fn get_top_movers(&self, query: Option<&MarketQuery>) -> Result<serde_json::Value> {
         let path = "/market-data/erc20s/top-movers";
         if let Some(q) = query {
@@ -65,6 +67,9 @@ impl<'a> MarketApi<'a> {
     }
 
     /// Get top NFT collections
+    #[deprecated(
+        note = "Moralis is sunsetting GET /market-data/nfts/top-collections on 2026-06-04"
+    )]
     pub async fn get_top_nft_collections(
         &self,
         query: Option<&MarketQuery>,
@@ -78,6 +83,9 @@ impl<'a> MarketApi<'a> {
     }
 
     /// Get hottest NFT collections
+    #[deprecated(
+        note = "Moralis is sunsetting GET /market-data/nfts/hottest-collections on 2026-06-04"
+    )]
     pub async fn get_hottest_nft_collections(
         &self,
         query: Option<&MarketQuery>,
@@ -91,11 +99,13 @@ impl<'a> MarketApi<'a> {
     }
 
     /// Get global market cap
+    #[deprecated(note = "Moralis is sunsetting GET /market-data/global/market-cap on 2026-06-04")]
     pub async fn get_global_market_cap(&self) -> Result<GlobalMarketCap> {
         self.client.get("/market-data/global/market-cap").await
     }
 
     /// Get global volume
+    #[deprecated(note = "Moralis is sunsetting GET /market-data/global/volume on 2026-06-04")]
     pub async fn get_global_volume(&self) -> Result<GlobalVolume> {
         self.client.get("/market-data/global/volume").await
     }

--- a/crates/mrls/src/token/api.rs
+++ b/crates/mrls/src/token/api.rs
@@ -242,6 +242,7 @@ impl<'a> TokenApi<'a> {
     }
 
     /// Get token stats
+    #[deprecated(note = "Moralis is sunsetting GET /erc20/{address}/stats on 2026-06-04")]
     pub async fn get_stats(&self, address: &str, chain: Option<&str>) -> Result<TokenStats> {
         let path = format!("/erc20/{address}/stats");
         if let Some(chain) = chain {
@@ -323,6 +324,9 @@ impl<'a> TokenApi<'a> {
     }
 
     /// Get new tokens on an exchange
+    #[deprecated(
+        note = "Moralis is sunsetting GET /erc20/exchange/{exchangeName}/new on 2026-06-04"
+    )]
     pub async fn get_exchange_new_tokens(
         &self,
         exchange_name: &str,
@@ -338,6 +342,9 @@ impl<'a> TokenApi<'a> {
     }
 
     /// Get bonding tokens on an exchange (e.g., pump.fun)
+    #[deprecated(
+        note = "Moralis is sunsetting GET /erc20/exchange/{exchangeName}/bonding on 2026-06-04"
+    )]
     pub async fn get_exchange_bonding_tokens(
         &self,
         exchange_name: &str,
@@ -353,6 +360,9 @@ impl<'a> TokenApi<'a> {
     }
 
     /// Get graduated tokens on an exchange
+    #[deprecated(
+        note = "Moralis is sunsetting GET /erc20/exchange/{exchangeName}/graduated on 2026-06-04"
+    )]
     pub async fn get_exchange_graduated_tokens(
         &self,
         exchange_name: &str,
@@ -384,6 +394,9 @@ impl<'a> TokenApi<'a> {
     }
 
     /// Get tokens by symbols
+    #[deprecated(
+        note = "Moralis is sunsetting GET /erc20/metadata/symbols on 2026-06-04; use token search instead"
+    )]
     pub async fn get_by_symbols(
         &self,
         symbols: &[&str],
@@ -455,6 +468,9 @@ impl<'a> TokenApi<'a> {
     }
 
     /// Get aggregated token pair stats
+    #[deprecated(
+        note = "Moralis is sunsetting GET /erc20/{token_address}/pairs/stats on 2026-06-04; migrate to /tokens/{tokenAddress}/analytics"
+    )]
     pub async fn get_pairs_stats(
         &self,
         address: &str,
@@ -485,6 +501,7 @@ impl<'a> TokenApi<'a> {
     }
 
     /// Get pair snipers
+    #[deprecated(note = "Moralis is sunsetting GET /pairs/{address}/snipers on 2026-06-04")]
     pub async fn get_pair_snipers(
         &self,
         pair_address: &str,
@@ -500,6 +517,9 @@ impl<'a> TokenApi<'a> {
     }
 
     /// Get token bonding status (for pump.fun, etc)
+    #[deprecated(
+        note = "Moralis is sunsetting GET /erc20/{tokenAddress}/bondingStatus on 2026-06-04"
+    )]
     pub async fn get_bonding_status(
         &self,
         address: &str,

--- a/crates/mrls/src/volume/api.rs
+++ b/crates/mrls/src/volume/api.rs
@@ -61,16 +61,19 @@ impl<'a> VolumeApi<'a> {
     }
 
     /// Get volume by chain
+    #[deprecated(note = "Moralis is sunsetting GET /volume/chains on 2026-06-04")]
     pub async fn get_chains_volume(&self) -> Result<Vec<ChainVolume>> {
         self.client.get("/volume/chains").await
     }
 
     /// Get volume by category
+    #[deprecated(note = "Moralis is sunsetting GET /volume/categories on 2026-06-04")]
     pub async fn get_categories_volume(&self) -> Result<Vec<CategoryVolume>> {
         self.client.get("/volume/categories").await
     }
 
     /// Get overall volume timeseries
+    #[deprecated(note = "Moralis is sunsetting GET /volume/timeseries on 2026-06-04")]
     pub async fn get_timeseries(&self, query: Option<&VolumeQuery>) -> Result<VolumeTimeseries> {
         if let Some(q) = query {
             self.client.get_with_query("/volume/timeseries", q).await
@@ -80,6 +83,7 @@ impl<'a> VolumeApi<'a> {
     }
 
     /// Get volume timeseries for a category
+    #[deprecated(note = "Moralis is sunsetting GET /volume/timeseries/{category_id} on 2026-06-04")]
     pub async fn get_category_timeseries(
         &self,
         category_id: &str,

--- a/crates/mrls/tests/live_api.rs
+++ b/crates/mrls/tests/live_api.rs
@@ -2,6 +2,11 @@
 //!
 //! Run with: MORALIS_API_KEY=your_key cargo test -p mrls --test live_api -- --ignored
 
+#![allow(deprecated)]
+
+// These ignored live tests intentionally cover Moralis legacy endpoints until
+// their 2026-06-04 sunset date.
+
 use mrls::Client;
 
 /// Vitalik's address for testing


### PR DESCRIPTION
## Summary

- Block Moralis Fantom chain aliases (fantom, ftm, 250, 0xfa) before client setup because Moralis is removing Fantom support on 2026-05-29.
- Add preflight guards for Moralis endpoints scheduled for removal on 2026-06-04: legacy Discovery, Volume, Market Data, pair sniper, and selected ERC20 helper commands.
- Mark the affected mrls client methods with deprecated notes and update ethcli/mrls/MCP docs.

## Impact

Deprecated ethcli moralis commands now fail with migration-focused errors before requiring MORALIS_API_KEY. MCP moralis_* wrappers inherit the same behavior because they execute ethcli commands.

Unaffected Moralis commands, including wallet, NFT, transaction, DeFi, normal token metadata/price/transfers/holders/swaps, and token analytics/score helpers, remain available.

## Validation

- cargo fmt
- cargo test -p ethcli moralis --lib
- cargo check -p ethcli
- cargo check -p ethcli-mcp
- cargo run -p ethcli --quiet -- moralis token pair-snipers 0xpair returned the expected deprecation error