### PR TITLE
chore: Dune Sim sunset guards (#62, #64)

### DIFF
--- a/crates/dnsim/README.md
+++ b/crates/dnsim/README.md
@@ -13,13 +13,19 @@
   <a href="https://github.com/yldfi/yldfi-rs/blob/main/crates/dune-sim/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License"></a>
 </p>
 
+> [!WARNING]
+> Dune is shutting down the Sim platform on **2026-08-01**; this crate stops
+> working then. The DeFi Positions endpoints were already deprecated on
+> 2026-06-01 and the `defi()` API is short-circuited to always return an
+> error. See <https://github.com/yldfi/yldfi-rs/issues/64>.
+
 ## Features
 
 - **Chains** - List supported chains
 - **Balances** - Get wallet token balances across chains
 - **Activity** - Get wallet transaction history
 - **Collectibles** - Get NFT holdings
-- **DeFi** - Get DeFi protocol positions
+- **DeFi** - Removed (deprecated by Dune on 2026-06-01; calls always error)
 - **Tokens** - Get token metadata
 - **Holders** - Get token holders
 - **Transactions** - Get transaction details

--- a/crates/dnsim/src/defi/api.rs
+++ b/crates/dnsim/src/defi/api.rs
@@ -4,6 +4,9 @@ use super::types::{DefiPositionsOptions, DefiPositionsResponse};
 use crate::client::Client;
 use crate::error::Result;
 
+/// Error message returned for the removed `DeFi` Positions endpoints
+pub const DEFI_POSITIONS_SUNSET_MESSAGE: &str = "Dune Sim DeFi Positions was deprecated 2026-06-01 and the Sim platform shuts down 2026-08-01. See https://github.com/yldfi/yldfi-rs/issues/64";
+
 /// `DeFi` API
 pub struct DefiApi<'a> {
     client: &'a Client,
@@ -17,32 +20,40 @@ impl<'a> DefiApi<'a> {
 
     /// Get `DeFi` positions for a wallet (Beta)
     ///
-    /// Note: This endpoint is temporarily unavailable during rearchitecting.
+    /// Note: Dune deprecated this endpoint on 2026-06-01; the call is
+    /// short-circuited and always returns an error.
     ///
     /// # Arguments
     /// * `address` - Wallet address
+    ///
+    /// # Errors
+    /// Always returns [`DEFI_POSITIONS_SUNSET_MESSAGE`]
+    #[deprecated(note = "Dune Sim DeFi Positions was deprecated 2026-06-01 (yldfi-rs issue #64)")]
     pub async fn positions(&self, address: &str) -> Result<DefiPositionsResponse> {
-        let path = format!("/beta/evm/defi/positions/{address}");
-        self.client.get(&path).await
+        // Endpoint removed upstream; short-circuit instead of issuing the request.
+        let _ = (self.client, address);
+        Err(crate::error::deprecated(DEFI_POSITIONS_SUNSET_MESSAGE))
     }
 
     /// Get `DeFi` positions with options (Beta)
     ///
-    /// Note: This endpoint is temporarily unavailable during rearchitecting.
+    /// Note: Dune deprecated this endpoint on 2026-06-01; the call is
+    /// short-circuited and always returns an error.
     ///
     /// # Arguments
     /// * `address` - Wallet address
     /// * `options` - Query options
+    ///
+    /// # Errors
+    /// Always returns [`DEFI_POSITIONS_SUNSET_MESSAGE`]
+    #[deprecated(note = "Dune Sim DeFi Positions was deprecated 2026-06-01 (yldfi-rs issue #64)")]
     pub async fn positions_with_options(
         &self,
         address: &str,
         options: &DefiPositionsOptions,
     ) -> Result<DefiPositionsResponse> {
-        let path = format!(
-            "/beta/evm/defi/positions/{}{}",
-            address,
-            options.to_query_string()
-        );
-        self.client.get(&path).await
+        // Endpoint removed upstream; short-circuit instead of issuing the request.
+        let _ = (self.client, address, options);
+        Err(crate::error::deprecated(DEFI_POSITIONS_SUNSET_MESSAGE))
     }
 }

--- a/crates/dnsim/src/defi/mod.rs
+++ b/crates/dnsim/src/defi/mod.rs
@@ -1,7 +1,12 @@
 //! `DeFi` positions module (Beta)
+//!
+//! Dune deprecated the `DeFi` Positions endpoints on 2026-06-01 and the Sim
+//! platform shuts down on 2026-08-01. The API handlers are short-circuited
+//! and always return an error; the types remain for deserializing archived
+//! responses. See <https://github.com/yldfi/yldfi-rs/issues/64>.
 
 mod api;
 mod types;
 
-pub use api::DefiApi;
+pub use api::{DefiApi, DEFI_POSITIONS_SUNSET_MESSAGE};
 pub use types::*;

--- a/crates/dnsim/src/error.rs
+++ b/crates/dnsim/src/error.rs
@@ -21,6 +21,10 @@ pub enum DomainError {
     #[error("Bad request: {0}")]
     BadRequest(String),
 
+    /// Deprecated endpoint removed by the provider
+    #[error("Deprecated: {0}")]
+    Deprecated(String),
+
     /// URL parse error
     #[error("URL parse error: {0}")]
     UrlParse(#[from] url::ParseError),
@@ -46,6 +50,11 @@ pub fn not_found(resource: impl Into<String>) -> Error {
 /// Create a bad request error
 pub fn bad_request(message: impl Into<String>) -> Error {
     ApiError::domain(DomainError::BadRequest(message.into()))
+}
+
+/// Create a deprecated endpoint error
+pub fn deprecated(message: impl Into<String>) -> Error {
+    ApiError::domain(DomainError::Deprecated(message.into()))
 }
 
 /// Create from HTTP response status and body

--- a/crates/dnsim/src/tests.rs
+++ b/crates/dnsim/src/tests.rs
@@ -703,3 +703,33 @@ mod deserialization_tests {
         assert!(response.next_offset.is_some());
     }
 }
+
+#[cfg(test)]
+mod defi_sunset_tests {
+    use crate::defi::{DefiPositionsOptions, DEFI_POSITIONS_SUNSET_MESSAGE};
+
+    #[tokio::test]
+    async fn defi_positions_is_short_circuited() {
+        let client = crate::Client::new("test-key").unwrap();
+        #[allow(deprecated)]
+        let error = client
+            .defi()
+            .positions("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains(DEFI_POSITIONS_SUNSET_MESSAGE));
+    }
+
+    #[tokio::test]
+    async fn defi_positions_with_options_is_short_circuited() {
+        let client = crate::Client::new("test-key").unwrap();
+        let options = DefiPositionsOptions::default();
+        #[allow(deprecated)]
+        let error = client
+            .defi()
+            .positions_with_options("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", &options)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains(DEFI_POSITIONS_SUNSET_MESSAGE));
+    }
+}

--- a/crates/ethcli-mcp/README.md
+++ b/crates/ethcli-mcp/README.md
@@ -115,7 +115,7 @@ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":
 | cowswap_* | 8 |
 | account_* | 8 |
 | oneinch_* | 7 |
-| dsim_* | 7 |
+| dsim_* | 6 |
 | ccxt_* | 7 |
 | blacklist_* | 7 |
 | address_* | 7 |
@@ -162,6 +162,7 @@ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":
 | `ONEINCH_API_KEY` | `oneinch_*` tools |
 | `ENSO_API_KEY` | `enso_*` tools |
 | `DUNE_API_KEY` | `dune_*` tools |
+| `DUNE_SIM_API_KEY` | `dsim_*` tools (sunset 2026-08-01; `DUNE_API_KEY` is not a fallback) |
 | `MORALIS_API_KEY` | `moralis_*` tools |
 | `SOLODIT_API_KEY` | `solodit_*` tools |
 | `THEGRAPH_API_KEY` | `uniswap_top_pools`, etc. |
@@ -170,6 +171,12 @@ Moralis is removing Fantom support on 2026-05-29 and selected legacy Data API
 endpoints on 2026-06-04. The MCP `moralis_*` tools inherit the same ethcli
 guards for Fantom and deprecated Discovery, Volume, Market Data, pair sniper,
 and selected ERC20 helper endpoints.
+
+Dune is shutting down the Sim platform on 2026-08-01. The remaining `dsim_*`
+tools keep working until then (with a stderr sunset warning from ethcli), but
+the `dsim_defi` tool was removed because the DeFi Positions endpoints were
+deprecated on 2026-06-01. See
+<https://github.com/yldfi/yldfi-rs/issues/64>.
 
 ## Unverified Contract Analysis
 

--- a/crates/ethcli-mcp/src/main.rs
+++ b/crates/ethcli-mcp/src/main.rs
@@ -4586,7 +4586,8 @@ impl EthcliMcpServer {
     }
 
     // =========================================================================
-    // DSIM (Dune Simulator)
+    // DSIM (Dune Sim) - platform shuts down 2026-08-01
+    // (https://github.com/yldfi/yldfi-rs/issues/64)
     // =========================================================================
 
     #[tool(description = "List supported chains for Dune Simulator")]
@@ -4623,10 +4624,8 @@ impl EthcliMcpServer {
             .to_response()
     }
 
-    #[tool(description = "Get DeFi positions via Dune Simulator")]
-    async fn dsim_defi(&self, Parameters(input): Parameters<DsimAddressInput>) -> String {
-        tools::dsim_defi(&input.address).await.to_response()
-    }
+    // dsim_defi was removed: Dune Sim DeFi Positions was deprecated 2026-06-01
+    // and the Sim platform shuts down 2026-08-01. See issue #64.
 
     // =========================================================================
     // DUNE

--- a/crates/ethcli-mcp/src/tools.rs
+++ b/crates/ethcli-mcp/src/tools.rs
@@ -5866,7 +5866,7 @@ pub async fn moralis_volume_category_timeseries(
 }
 
 // =============================================================================
-// DSIM (7 subcommands) - Dune Sim
+// DSIM (6 subcommands) - Dune Sim (platform shuts down 2026-08-01, issue #64)
 // =============================================================================
 
 pub async fn dsim_chains() -> Result<String, ToolError> {
@@ -5929,15 +5929,8 @@ pub async fn dsim_holders(token: &str, chain_id: Option<&str>) -> Result<String,
         .map_err(ToolError::from)
 }
 
-pub async fn dsim_defi(address: &str) -> Result<String, ToolError> {
-    ArgsBuilder::new("dsim")
-        .subcommand("defi")
-        .subcommand("positions")
-        .arg(address)
-        .execute()
-        .await
-        .map_err(ToolError::from)
-}
+// dsim_defi was removed: Dune Sim DeFi Positions was deprecated 2026-06-01
+// and the Sim platform shuts down 2026-08-01. See issue #64.
 
 // =============================================================================
 // DUNE (3 subcommands)

--- a/crates/ethcli-mcp/src/types.rs
+++ b/crates/ethcli-mcp/src/types.rs
@@ -470,7 +470,8 @@ pub struct PortfolioInput {
     pub aggregate: bool,
     /// Chain(s) to query (default: ethereum)
     pub chain: Option<String>,
-    /// Source to query: all, alchemy, moralis, dsim, uniswap, yearn
+    /// Source to query: all, alchemy, moralis, dsim, uniswap, yearn.
+    /// "all" excludes dsim (Dune Sim shuts down 2026-08-01, issue #64).
     pub source: Option<String>,
     /// Minimum USD value to show (filter small balances)
     pub min_value: Option<f64>,

--- a/crates/ethcli/CLAUDE.md
+++ b/crates/ethcli/CLAUDE.md
@@ -658,14 +658,15 @@ ethcli moralis defi-positions 0x...
 
 ## Dsim (Dune SIM) Commands
 
-Direct access to Dune SIM API. Requires `DUNE_SIM_API_KEY` environment variable.
+Direct access to Dune SIM API. Requires `DUNE_SIM_API_KEY` environment variable
+(`DUNE_API_KEY` is not a fallback). Dune Sim shuts down 2026-08-01 (issue #64);
+`ethcli dsim defi` is blocked because DeFi Positions was deprecated 2026-06-01.
 
 ```bash
 # Wallet simulation
 ethcli dsim balances 0x...
 ethcli dsim activity 0x...
 ethcli dsim collectibles 0x...
-ethcli dsim defi 0x...
 ```
 
 ## Dune Commands

--- a/crates/ethcli/LLMREF.md
+++ b/crates/ethcli/LLMREF.md
@@ -228,11 +228,14 @@ ethcli solodit get <slug>
 ```
 
 ### Dune SIM (requires DUNE_SIM_API_KEY)
+Dune Sim shuts down 2026-08-01 (yldfi-rs issue #64); dsim commands print a
+sunset warning to stderr. `ethcli dsim defi` is blocked (DeFi Positions was
+deprecated 2026-06-01). DUNE_API_KEY is no longer accepted as a fallback.
+
 ```bash
 ethcli dsim balances <addr>         # Wallet balances
 ethcli dsim activity <addr>         # Wallet activity
 ethcli dsim collectibles <addr>     # NFTs
-ethcli dsim defi <addr>             # DeFi positions
 ```
 
 ### Curve
@@ -364,7 +367,7 @@ ethcli doctor                       # Diagnose issues
 | MORALIS_API_KEY | moralis commands | Moralis API |
 | COINGECKO_API_KEY | Optional | CoinGecko Pro |
 | DUNE_API_KEY | dune commands | Dune Analytics |
-| DUNE_SIM_API_KEY | dsim commands | Dune SIM |
+| DUNE_SIM_API_KEY | dsim commands | Dune SIM (sunset 2026-08-01) |
 | TENDERLY_ACCESS_KEY | tenderly commands | Tenderly API |
 | THEGRAPH_API_KEY | uniswap subgraph | The Graph |
 | GOPLUS_APP_KEY | Optional | GoPlus batch queries |

--- a/crates/ethcli/README.md
+++ b/crates/ethcli/README.md
@@ -35,8 +35,8 @@
 
 ### Aggregation Commands
 - **Price Aggregation**: Multi-source prices from CoinGecko, DefiLlama, Alchemy, Moralis, Chainlink, Pyth, CCXT
-- **Portfolio Aggregation**: Balance data from Alchemy, Dune SIM, Moralis
-- **NFT Aggregation**: Holdings from Alchemy, CoinGecko, Moralis, Dune SIM
+- **Portfolio Aggregation**: Balance data from Alchemy, Moralis (Dune SIM only via `--source dsim` until the 2026-08-01 sunset)
+- **NFT Aggregation**: Holdings from Alchemy, CoinGecko, Moralis (Dune SIM only via `--source dsim` until the 2026-08-01 sunset)
 - **Yield Aggregation**: DeFi yields from DefiLlama and Curve
 - **Quote Aggregation**: Swap quotes from OpenOcean, KyberSwap, 0x, 1inch, CowSwap, LI.FI, Velora, Enso
 
@@ -45,7 +45,7 @@
 - **CoinGecko**: Coins, prices, NFTs, exchanges
 - **DefiLlama**: TVL, prices, yields, stablecoins
 - **Moralis**: Wallet, token, NFT, DeFi, transactions
-- **Dune SIM**: Balances, activity, collectibles, DeFi positions
+- **Dune SIM**: Balances, activity, collectibles (sunsetting 2026-08-01; DeFi positions removed)
 - **Dune Analytics**: Queries, executions, tables
 - **Curve Finance**: Pools, volumes, lending, tokens, router
 - **Chainlink**: Price feeds (RPC-based, no API key needed)
@@ -522,7 +522,7 @@ ethcli portfolio 0x... --chain polygon
 ethcli portfolio 0x... -o json
 ```
 
-**Sources**: Alchemy, Dune SIM, Moralis
+**Sources**: Alchemy, Moralis (Dune SIM via `--source dsim` only; sunset 2026-08-01)
 
 ### NFTs - Multi-Source NFT Aggregation
 
@@ -535,7 +535,7 @@ ethcli nfts 0x... --chain polygon
 ethcli nfts 0x... -o json
 ```
 
-**Sources**: Alchemy, CoinGecko, Moralis, Dune SIM
+**Sources**: Alchemy, CoinGecko, Moralis (Dune SIM via `--source dsim` only; sunset 2026-08-01)
 
 ### Yields - DeFi Yield Aggregation
 
@@ -695,14 +695,19 @@ ethcli moralis defi-positions 0x...
 
 ### Dsim - Dune SIM API
 
-Requires `DUNE_SIM_API_KEY` environment variable.
+Requires `DUNE_SIM_API_KEY` environment variable (Dune Analytics keys are no
+longer accepted as a fallback).
+
+Dune is shutting down the Sim platform on 2026-08-01; every `ethcli dsim`
+command prints a sunset warning to stderr until then. The DeFi Positions
+endpoints were deprecated on 2026-06-01, so `ethcli dsim defi` now returns an
+error. See <https://github.com/yldfi/yldfi-rs/issues/64>.
 
 ```bash
 # Wallet simulation
 ethcli dsim balances 0x...
 ethcli dsim activity 0x...
 ethcli dsim collectibles 0x...
-ethcli dsim defi 0x...
 ```
 
 ### Dune - Dune Analytics API
@@ -1054,7 +1059,7 @@ ethcli config set-etherscan-key YOUR_KEY
 | `COINGECKO_API_KEY` | Optional | CoinGecko Pro API (higher rate limits) |
 | `DEFILLAMA_API_KEY` | Optional | DefiLlama Pro endpoints |
 | `MORALIS_API_KEY` | `ethcli moralis` | Moralis API access |
-| `DUNE_SIM_API_KEY` | `ethcli dsim` | Dune SIM wallet simulation |
+| `DUNE_SIM_API_KEY` | `ethcli dsim` | Dune SIM wallet simulation (sunset 2026-08-01) |
 | `DUNE_API_KEY` | `ethcli dune` | Dune Analytics queries |
 | `THEGRAPH_API_KEY` | Uniswap subgraph | The Graph API access |
 | `CHAINLINK_API_KEY` | `chainlink streams` | Chainlink Data Streams (premium) |

--- a/crates/ethcli/src/aggregator/nft.rs
+++ b/crates/ethcli/src/aggregator/nft.rs
@@ -30,8 +30,13 @@ impl NftSource {
         }
     }
 
+    /// Default source set for `--source all`
+    ///
+    /// Dune Sim is excluded because the platform shuts down on 2026-08-01
+    /// (<https://github.com/yldfi/yldfi-rs/issues/64>); it can still be
+    /// queried explicitly via `--source dsim` until then.
     pub fn all_sources() -> Vec<NftSource> {
-        vec![NftSource::Alchemy, NftSource::Moralis, NftSource::DuneSim]
+        vec![NftSource::Alchemy, NftSource::Moralis]
     }
 }
 
@@ -612,7 +617,9 @@ async fn fetch_nfts_moralis(address: &str, chains: &[&str]) -> anyhow::Result<Ve
 
 /// Fetch NFTs from Dune SIM (Collectibles API)
 async fn fetch_nfts_dsim(address: &str, chains: &[&str]) -> anyhow::Result<Vec<NftEntry>> {
-    // Get API key from config first, then fall back to env var
+    // Get API key from config first, then fall back to env var. Dune Analytics
+    // keys are not valid Sim credentials, so there is intentionally no
+    // DUNE_API_KEY fallback.
     let config = get_cached_config();
     let api_key = config
         .as_ref()
@@ -620,17 +627,8 @@ async fn fetch_nfts_dsim(address: &str, chains: &[&str]) -> anyhow::Result<Vec<N
             c.dune_sim
                 .as_ref()
                 .map(|d| d.api_key.expose_secret().to_string())
-                .or_else(|| {
-                    c.dune
-                        .as_ref()
-                        .map(|d| d.api_key.expose_secret().to_string())
-                })
         })
-        .or_else(|| {
-            std::env::var("DUNE_SIM_API_KEY")
-                .or_else(|_| std::env::var("DUNE_API_KEY"))
-                .ok()
-        })
+        .or_else(|| std::env::var("DUNE_SIM_API_KEY").ok())
         .ok_or_else(|| anyhow::anyhow!("DUNE_SIM_API_KEY not set in config or environment"))?;
 
     let client = dnsim::Client::new(&api_key)?;

--- a/crates/ethcli/src/aggregator/portfolio.rs
+++ b/crates/ethcli/src/aggregator/portfolio.rs
@@ -154,6 +154,10 @@ pub struct MergedToken {
 }
 
 /// Fetch portfolio from all available sources in parallel
+///
+/// Dune Sim is excluded from the default set because the platform shuts down
+/// on 2026-08-01 (<https://github.com/yldfi/yldfi-rs/issues/64>); it can still
+/// be queried explicitly via `--source dsim` until then.
 pub async fn fetch_portfolio_all(
     address: &str,
     chains: &[&str],
@@ -161,7 +165,6 @@ pub async fn fetch_portfolio_all(
     let sources = vec![
         PortfolioSource::Alchemy,
         PortfolioSource::Moralis,
-        PortfolioSource::DuneSim,
         PortfolioSource::Uniswap,
         PortfolioSource::Yearn,
     ];

--- a/crates/ethcli/src/cli/dsim.rs
+++ b/crates/ethcli/src/cli/dsim.rs
@@ -6,6 +6,17 @@ use crate::cli::OutputFormat;
 use crate::config::ConfigFile;
 use clap::{Args, Subcommand};
 
+const DUNE_SIM_SUNSET_WARNING: &str = "WARNING: Dune Sim shuts down 2026-08-01 (issue #64)";
+const DUNE_SIM_DEFI_REMOVED: &str = "Dune Sim DeFi Positions was deprecated 2026-06-01 and the Sim platform shuts down 2026-08-01. See https://github.com/yldfi/yldfi-rs/issues/64";
+
+/// Reject subcommands whose Dune Sim endpoints have already been removed
+fn reject_removed_dsim_command(command: &DsimCommands) -> anyhow::Result<()> {
+    match command {
+        DsimCommands::Defi { .. } => anyhow::bail!(DUNE_SIM_DEFI_REMOVED),
+        _ => Ok(()),
+    }
+}
+
 #[derive(Args)]
 pub struct DsimArgs {
     /// Output format
@@ -140,21 +151,23 @@ pub enum DefiCommands {
 pub async fn handle(command: &DsimCommands, quiet: bool) -> anyhow::Result<()> {
     use secrecy::ExposeSecret;
 
-    // Try config first, then fall back to env var
+    reject_removed_dsim_command(command)?;
+
+    if !quiet {
+        eprintln!("{DUNE_SIM_SUNSET_WARNING}");
+    }
+
+    // Try config first, then fall back to env var. Dune Analytics keys are not
+    // valid Sim credentials, so there is intentionally no DUNE_API_KEY fallback.
     let api_key = if let Ok(Some(config)) = ConfigFile::load_default() {
         if let Some(ref dune_sim_config) = config.dune_sim {
             dune_sim_config.api_key.expose_secret().to_string()
-        } else if let Some(ref dune_config) = config.dune {
-            // Fall back to Dune Analytics key if no SIM-specific key
-            dune_config.api_key.expose_secret().to_string()
         } else {
             std::env::var("DUNE_SIM_API_KEY")
-                .or_else(|_| std::env::var("DUNE_API_KEY"))
                 .map_err(|_| anyhow::anyhow!("DUNE_SIM_API_KEY not set in config or environment"))?
         }
     } else {
         std::env::var("DUNE_SIM_API_KEY")
-            .or_else(|_| std::env::var("DUNE_API_KEY"))
             .map_err(|_| anyhow::anyhow!("DUNE_SIM_API_KEY not set in config or environment"))?
     };
 
@@ -279,6 +292,9 @@ async fn handle_holders(
     Ok(())
 }
 
+// Unreachable behind `reject_removed_dsim_command`; kept compiled until the
+// 2026-08-01 Sim sunset removes the command tree entirely.
+#[allow(deprecated)]
 async fn handle_defi(
     client: &dnsim::Client,
     action: &DefiCommands,
@@ -310,4 +326,50 @@ fn print_output<T: serde::Serialize>(data: &T, format: OutputFormat) -> anyhow::
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        reject_removed_dsim_command, BalancesCommands, DefiCommands, DsimArgs, DsimCommands,
+        OutputFormat, DUNE_SIM_DEFI_REMOVED,
+    };
+
+    fn dsim_args() -> DsimArgs {
+        DsimArgs {
+            format: OutputFormat::Json,
+        }
+    }
+
+    #[test]
+    fn dsim_defi_positions_is_rejected() {
+        let command = DsimCommands::Defi {
+            action: DefiCommands::Positions {
+                address: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045".to_string(),
+            },
+            args: dsim_args(),
+        };
+
+        let error = reject_removed_dsim_command(&command)
+            .expect_err("dsim defi should be rejected")
+            .to_string();
+        assert_eq!(error, DUNE_SIM_DEFI_REMOVED);
+    }
+
+    #[test]
+    fn other_dsim_commands_still_pass_the_guard() {
+        let commands = [
+            DsimCommands::Chains { args: dsim_args() },
+            DsimCommands::Balances {
+                action: BalancesCommands::Get {
+                    address: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045".to_string(),
+                },
+                args: dsim_args(),
+            },
+        ];
+
+        for command in &commands {
+            assert!(reject_removed_dsim_command(command).is_ok());
+        }
+    }
 }

--- a/crates/ethcli/src/cli/nfts.rs
+++ b/crates/ethcli/src/cli/nfts.rs
@@ -18,7 +18,7 @@ pub enum NftSourceArg {
     Alchemy,
     /// Moralis NFT API
     Moralis,
-    /// Dune SIM Collectibles API
+    /// Dune SIM Collectibles API (sunset 2026-08-01; excluded from "all")
     Dsim,
 }
 

--- a/crates/ethcli/src/cli/portfolio.rs
+++ b/crates/ethcli/src/cli/portfolio.rs
@@ -28,7 +28,7 @@ pub enum PortfolioSourceArg {
     Alchemy,
     /// Moralis Wallet API
     Moralis,
-    /// Dune SIM Balances API
+    /// Dune SIM Balances API (sunset 2026-08-01; excluded from "all")
     Dsim,
     /// Uniswap V3 LP positions
     Uniswap,
@@ -61,7 +61,7 @@ impl From<PortfolioSourceArg> for PortfolioSource {
 Environment Variables:
   ALCHEMY_API_KEY     Required for Alchemy source
   MORALIS_API_KEY     Required for Moralis source
-  DUNE_SIM_API_KEY    Required for Dune SIM source
+  DUNE_SIM_API_KEY    Required for Dune SIM source (sunset 2026-08-01; excluded from "all")
   THEGRAPH_API_KEY    Required for Uniswap positions"#)]
 pub struct PortfolioArgs {
     /// Wallet address(es) to query (or labels from address book). Can specify multiple.


### PR DESCRIPTION
Time-critical guards for the Dune Sim shutdown (platform sunset 2026-08-01; DeFi Positions already dead since 2026-06-01). Addresses the guard/deprecation items of #62/#64 — replacement-provider selection is deferred.

- `ethcli dsim defi …` and `dnsim` `positions()` hard-fail with a clear sunset error (code kept compiling)
- MCP `dsim_defi` tool no longer advertised (verified via live `tools/list`)
- Dune Sim removed from default `portfolio --source all` and `nfts --source all`; explicit `--source dsim` still works until sunset
- Remaining `dsim` commands print a stderr sunset warning (respects `--quiet`)
- `DUNE_API_KEY` → Sim credential fallback removed (Dune Analytics usage untouched)
- Docs updated: ethcli README/LLMREF/CLAUDE.md, ethcli-mcp README, dnsim README

Tests: dnsim 23 pass, ethcli 329 pass, ethcli-mcp 24 pass; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)