### PR TITLE
chore(mrls): guard Moralis holders-historical sunset (2026-07-31)

### DIFF
--- a/crates/ethcli-mcp/README.md
+++ b/crates/ethcli-mcp/README.md
@@ -169,7 +169,10 @@ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":
 Moralis is removing Fantom support on 2026-05-29 and selected legacy Data API
 endpoints on 2026-06-04. The MCP `moralis_*` tools inherit the same ethcli
 guards for Fantom and deprecated Discovery, Volume, Market Data, pair sniper,
-and selected ERC20 helper endpoints.
+and selected ERC20 helper endpoints. `moralis_token_holders_historical`
+inherits the guard for the 2026-07-31 sunset of
+`GET /erc20/{address}/holders/historical`; `moralis_token_holders` and
+`moralis_token_holders_summary` remain supported.
 
 ## Unverified Contract Analysis
 

--- a/crates/ethcli-mcp/src/main.rs
+++ b/crates/ethcli-mcp/src/main.rs
@@ -3795,7 +3795,9 @@ impl EthcliMcpServer {
             .to_response()
     }
 
-    #[tool(description = "Get historical holders data for a token via Moralis")]
+    #[tool(
+        description = "Get historical holders data for a token via Moralis (Moralis is sunsetting this endpoint on 2026-07-31 and the call is blocked; use moralis_token_holders or moralis_token_holders_summary for current holder data)"
+    )]
     async fn moralis_token_holders_historical(
         &self,
         Parameters(input): Parameters<MoralisAddressInput>,

--- a/crates/ethcli/LLMREF.md
+++ b/crates/ethcli/LLMREF.md
@@ -179,7 +179,10 @@ ethcli llama yields --chain ethereum
 ### Moralis (requires MORALIS_API_KEY)
 Fantom is blocked for Moralis calls after Moralis' 2026-05-29 removal notice.
 Legacy Discovery, Volume, Market Data, selected ERC20 helper, and pair sniper
-commands are blocked ahead of the 2026-06-04 endpoint removal.
+commands are blocked ahead of the 2026-06-04 endpoint removal. The
+`token holders-historical` command is blocked ahead of the 2026-07-31 removal
+of `GET /erc20/{address}/holders/historical` (no documented replacement;
+`token holders` and `token holders-summary` remain supported).
 
 ```bash
 ethcli moralis balance <addr>

--- a/crates/ethcli/README.md
+++ b/crates/ethcli/README.md
@@ -672,7 +672,11 @@ Requires `MORALIS_API_KEY` environment variable.
 Moralis is removing Fantom support on 2026-05-29 and selected legacy Data API
 endpoints on 2026-06-04. `ethcli moralis` blocks Fantom chain aliases and the
 legacy Discovery, Volume, Market Data, pair sniper, and selected ERC20 helper
-commands affected by that changelog.
+commands affected by that changelog. Moralis is also sunsetting
+`GET /erc20/{address}/holders/historical` on 2026-07-31, so
+`ethcli moralis token holders-historical` is blocked as well; there is no
+documented replacement, and `token holders` and `token holders-summary` remain
+supported.
 
 ```bash
 # Wallet data

--- a/crates/ethcli/src/cli/moralis.rs
+++ b/crates/ethcli/src/cli/moralis.rs
@@ -8,6 +8,7 @@ use clap::{Args, Subcommand};
 
 const MORALIS_FANTOM_REMOVAL_DATE: &str = "2026-05-29";
 const MORALIS_LEGACY_REMOVAL_DATE: &str = "2026-06-04";
+const MORALIS_HOLDERS_HISTORICAL_REMOVAL_DATE: &str = "2026-07-31";
 
 fn ensure_moralis_chain_supported(chain: &str) -> anyhow::Result<()> {
     match chain.trim().to_ascii_lowercase().as_str() {
@@ -25,10 +26,24 @@ fn deprecated_moralis_endpoint(
     endpoints: &[&str],
     replacement: Option<&str>,
 ) -> anyhow::Result<()> {
+    deprecated_moralis_endpoint_with_date(
+        command,
+        endpoints,
+        MORALIS_LEGACY_REMOVAL_DATE,
+        replacement,
+    )
+}
+
+fn deprecated_moralis_endpoint_with_date(
+    command: &str,
+    endpoints: &[&str],
+    removal_date: &str,
+    replacement: Option<&str>,
+) -> anyhow::Result<()> {
     let endpoint_list = endpoints.join(", ");
     let mut message = format!(
         "`ethcli moralis {command}` calls Moralis endpoint(s) scheduled for removal on \
-         {MORALIS_LEGACY_REMOVAL_DATE}: {endpoint_list}."
+         {removal_date}: {endpoint_list}."
     );
 
     if let Some(replacement) = replacement {
@@ -84,6 +99,16 @@ fn reject_deprecated_moralis_command(command: &MoralisCommands) -> anyhow::Resul
                 "token by-symbols",
                 &["GET /erc20/metadata/symbols"],
                 Some("use `ethcli moralis token search <symbol>` for one symbol at a time"),
+            ),
+            TokenCommands::HoldersHistorical { .. } => deprecated_moralis_endpoint_with_date(
+                "token holders-historical",
+                &["GET /erc20/{address}/holders/historical"],
+                MORALIS_HOLDERS_HISTORICAL_REMOVAL_DATE,
+                Some(
+                    "use `ethcli moralis token holders` or `ethcli moralis token \
+                     holders-summary` for current holder data (Moralis documents no \
+                     historical replacement)",
+                ),
             ),
             TokenCommands::PairsStats { .. } => deprecated_moralis_endpoint(
                 "token pairs-stats",
@@ -2518,6 +2543,28 @@ mod tests {
 
         assert!(error.contains("pair-snipers"));
         assert!(error.contains("/pairs/{address}/snipers"));
+    }
+
+    #[test]
+    fn holders_historical_is_rejected_with_its_own_removal_date() {
+        let args = MoralisArgs {
+            chain: "eth".to_string(),
+            format: OutputFormat::Json,
+        };
+        let command = MoralisCommands::Token {
+            action: TokenCommands::HoldersHistorical {
+                address: "0xtoken".to_string(),
+            },
+            args,
+        };
+
+        let error = reject_deprecated_moralis_command(&command)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("holders-historical"));
+        assert!(error.contains("/erc20/{address}/holders/historical"));
+        assert!(error.contains("2026-07-31"));
     }
 
     #[test]

--- a/crates/mrls/README.md
+++ b/crates/mrls/README.md
@@ -34,6 +34,12 @@ affected `mrls` methods are annotated with `#[deprecated]`, including legacy
 Discovery, Volume, Market Data, selected ERC20 stats/discovery helpers, and pair
 sniper endpoints.
 
+Moralis also announced on 2026-06-30 that it is sunsetting
+`GET /erc20/{address}/holders/historical` on 2026-07-31, so
+`TokenApi::get_holders_historical` is annotated with `#[deprecated]`. There is
+no documented replacement; `get_holders` and `get_holders_summary` remain
+supported.
+
 ## Installation
 
 ```toml

--- a/crates/mrls/src/token/api.rs
+++ b/crates/mrls/src/token/api.rs
@@ -453,6 +453,9 @@ impl<'a> TokenApi<'a> {
     }
 
     /// Get historical holders data for a token
+    #[deprecated(
+        note = "Moralis is sunsetting GET /erc20/{address}/holders/historical on 2026-07-31"
+    )]
     pub async fn get_holders_historical(
         &self,
         address: &str,


### PR DESCRIPTION
Moralis announced 2026-06-30 that `GET /erc20/{address}/holders/historical` sunsets **2026-07-31**. This applies the same guard pattern as #63: `#[deprecated]` on `TokenApi::get_holders_historical`, hard-reject of `ethcli moralis token holders-historical` with a migration hint (`token holders` / `holders-summary` remain supported), MCP tool description annotated, README/LLMREF updates, and a unit test pinning the removal date.

Follow-up worth tracking: the ~29 endpoints guarded in #63 were removed server-side on 2026-06-04, so a future breaking release could delete them outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)